### PR TITLE
Reverts access modifier for AsyncEventConsumer.cs

### DIFF
--- a/EasyMQ.Consumer/AsyncEventConsumer.cs
+++ b/EasyMQ.Consumer/AsyncEventConsumer.cs
@@ -4,13 +4,9 @@ using EasyMQ.Abstractions;
 using EasyMQ.Abstractions.Consumer;
 using Microsoft.Extensions.Options;
 
-[assembly: InternalsVisibleTo("EasyMQ.E2E.Tests")]
-[assembly: InternalsVisibleTo("EasyMQ.Consumer.Tests")]
-
-
 namespace EasyMQ.Consumers;
 
-internal sealed class AsyncEventConsumer<TEvent>: IEventConsumer
+public sealed class AsyncEventConsumer<TEvent>: IEventConsumer
     where TEvent: class, IEvent, new()
 {
     private readonly Func<IEventHandler<TEvent>> _handlerFactory;

--- a/EasyMQ.Consumer/EasyMQ.Consumer.csproj
+++ b/EasyMQ.Consumer/EasyMQ.Consumer.csproj
@@ -13,6 +13,15 @@
     </ItemGroup>
 
     <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>EasyMQ.E2E.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>EasyMQ.Consumer.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />


### PR DESCRIPTION
Even though compilation succeeds, at runtime NSubstitute is unable to create a proxy