### PR TITLE
Refactors existing extension method for consumers to accept THandler

### DIFF
--- a/EasyMQ.Abstractions/Consumer/ConsumerConfiguration.cs
+++ b/EasyMQ.Abstractions/Consumer/ConsumerConfiguration.cs
@@ -6,7 +6,8 @@ public class ConsumerConfiguration
     {
         Bindings = new List<Binding>();
     }
-    public string EventType { get; set; }
+    public string EventName { get; set; }
+    public string EventHandlerName { get; set; }
     public bool IsDurable { get; set; }
     public string QueueName { get; set; }
     public string ExchangeName { get; set; }

--- a/EasyMQ.Abstractions/Producer/RabbitProducerConfiguration.cs
+++ b/EasyMQ.Abstractions/Producer/RabbitProducerConfiguration.cs
@@ -2,7 +2,7 @@ namespace EasyMQ.Abstractions.Producer;
 
 public class RabbitProducerConfiguration
 {
-    public string EventType { get; set; }
+    public string EventName { get; set; }
     public string ExchangeName { get; set; }
     public string ExchangeType { get; set; }
     public bool ShouldDeclareExchange { get; set; }

--- a/EasyMQ.Consumer/AsyncEventConsumer.cs
+++ b/EasyMQ.Consumer/AsyncEventConsumer.cs
@@ -6,8 +6,9 @@ using Microsoft.Extensions.Options;
 
 namespace EasyMQ.Consumers;
 
-public sealed class AsyncEventConsumer<TEvent>: IEventConsumer
+public sealed class AsyncEventConsumer<TEvent, THandler>: IEventConsumer
     where TEvent: class, IEvent, new()
+    where THandler: IEventHandler<TEvent>
 {
     private readonly Func<IEventHandler<TEvent>> _handlerFactory;
     private readonly IOptions<List<ConsumerConfiguration>> _consumerConfiguration;
@@ -23,7 +24,7 @@ public sealed class AsyncEventConsumer<TEvent>: IEventConsumer
         var rabbitConfig = _consumerConfiguration.Value;
         var config = rabbitConfig.FirstOrDefault(
             c =>
-                c.EventType.Equals(typeof(TEvent).Name));
+                c.EventName.Equals(typeof(TEvent).Name) && c.EventHandlerName.Equals(typeof(THandler).Name));
         var bindings = config.Bindings.Select(configBinding => configBinding.Arguments).ToList();
         return new ConsumerQueueAndExchangeConfiguration()
         {

--- a/EasyMQ.Consumer/ServiceCollectionExtensions.cs
+++ b/EasyMQ.Consumer/ServiceCollectionExtensions.cs
@@ -27,8 +27,8 @@ public static class ServiceCollectionExtensions
             var scope = sp.CreateScope();
             return scope.ServiceProvider.GetRequiredService<IEventHandler<TEvent>>;
         });
-        services.AddSingleton<AsyncEventConsumer<TEvent>>();
-        services.AddHostedService<ConsumerEventHost<AsyncEventConsumer<TEvent>>>();
+        services.AddSingleton<AsyncEventConsumer<TEvent, THandler>>();
+        services.AddHostedService<ConsumerEventHost<AsyncEventConsumer<TEvent, THandler>>>();
         return services;
     }
 }

--- a/EasyMQ.Publisher/AsyncEventPublisher.cs
+++ b/EasyMQ.Publisher/AsyncEventPublisher.cs
@@ -35,7 +35,7 @@ public sealed class AsyncEventPublisher<TEvent> : IEventProducer<TEvent>, IEvent
     {
         var config = rabbitProducerConfigurations.FirstOrDefault(
             c =>
-                c.EventType.Equals(typeof(TEvent).Name));
+                c.EventName.Equals(typeof(TEvent).Name));
         return config;
     }
 

--- a/samples/EasyMQ.Console/appsettings.json
+++ b/samples/EasyMQ.Console/appsettings.json
@@ -1,7 +1,7 @@
 {
   "RabbitConsumerConfigurations": [
     {
-      "EventType": "EasyMqTopicEvent",
+      "EventName": "EasyMqTopicEvent",
       "QueueName": "easymq_q",
       "ExchangeName": "easymq.tx",
       "ExchangeType": "topic",
@@ -15,7 +15,7 @@
       "Bindings": []
     },
     {
-      "EventType": "EasyMqHeaderEvent",
+      "EventName": "EasyMqHeaderEvent",
       "QueueName": "header_q",
       "ExchangeName": "easymq.hx",
       "ExchangeType": "headers",
@@ -43,7 +43,7 @@
   ],
   "RabbitProducerConfigurations": [
     {
-      "EventType": "EasyMqTopicEvent",
+      "EventName": "EasyMqTopicEvent",
       "ExchangeName": "easymq.tx",
       "ExchangeType": "topic",
       "ShouldDeclareExchange": true,
@@ -52,7 +52,7 @@
       "RoutingKey": "test"
     },
     {
-      "EventType": "EasyMqHeaderEvent",
+      "EventName": "EasyMqHeaderEvent",
       "ExchangeName": "easymq.hx",
       "ExchangeType": "headers",
       "ShouldDeclareExchange": true,

--- a/tests/EasyMQ.Consumer.Tests/EventConsumerTests.cs
+++ b/tests/EasyMQ.Consumer.Tests/EventConsumerTests.cs
@@ -8,17 +8,23 @@ using EasyMQ.Abstractions.Consumer;
 using EasyMQ.Consumers;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using NSubstitute;
 using Xunit;
 
 namespace EasyMQ.Consumer.Tests;
 
+class TestHandler : IEventHandler<EventConsumerTests.TestEvent>
+{
+    public Task Handle(ReceiverContext receiverContext, EventConsumerTests.TestEvent @event)
+    {
+        throw new NotImplementedException();
+    }
+}
 public class EventConsumerTests
 {
     private readonly IEventHandler<TestEvent> _eventHandler;
     private readonly IOptions<List<ConsumerConfiguration>> _consumerConfigs;
-    private readonly AsyncEventConsumer<TestEvent> _consumer;
+    private readonly AsyncEventConsumer<TestEvent, TestHandler> _consumer;
 
     public class TestEvent : IEvent
     {
@@ -33,10 +39,11 @@ public class EventConsumerTests
         {
             new ConsumerConfiguration()
             {
-                EventType = "TestEvent",
+                EventName = "TestEvent",
+                EventHandlerName = "TestHandler"
             }
         });
-        _consumer = new AsyncEventConsumer<TestEvent>(handlerFactory, _consumerConfigs);
+        _consumer = new AsyncEventConsumer<TestEvent, TestHandler>(handlerFactory, _consumerConfigs);
     }
 
     [Fact]

--- a/tests/EasyMQ.E2E.Tests/HeaderEndToEndTests.cs
+++ b/tests/EasyMQ.E2E.Tests/HeaderEndToEndTests.cs
@@ -25,8 +25,8 @@ public class HeaderEndToEndTests: Fixture
             .AddEventConsumer<HeaderEvent, HeaderEventHandler>()
             .AddEventProducer<HeaderEvent>()
             .AddSingleton(_topicLogger)
-            .AddTransient<ILogger<ConsumerEventHost<AsyncEventConsumer<HeaderEvent>>>>(sp =>
-                Substitute.For<ILogger<ConsumerEventHost<AsyncEventConsumer<HeaderEvent>>>>());
+            .AddTransient<ILogger<ConsumerEventHost<AsyncEventConsumer<HeaderEvent, HeaderEventHandler>>>>(sp =>
+                Substitute.For<ILogger<ConsumerEventHost<AsyncEventConsumer<HeaderEvent, HeaderEventHandler>>>>());
         
         base.AddServices(services, configurationRoot);
     }

--- a/tests/EasyMQ.E2E.Tests/TopicEndToEndTests.cs
+++ b/tests/EasyMQ.E2E.Tests/TopicEndToEndTests.cs
@@ -24,8 +24,8 @@ public class TopicEndToEndTests: Fixture
             .AddEventConsumer<TopicEvent, TopicEventHandler>()
             .AddEventProducer<TopicEvent>()
             .AddSingleton(_topicLogger)
-            .AddTransient<ILogger<ConsumerEventHost<AsyncEventConsumer<TopicEvent>>>>(sp =>
-                Substitute.For<ILogger<ConsumerEventHost<AsyncEventConsumer<TopicEvent>>>>());
+            .AddTransient<ILogger<ConsumerEventHost<AsyncEventConsumer<TopicEvent, TopicEventHandler>>>>(sp =>
+                Substitute.For<ILogger<ConsumerEventHost<AsyncEventConsumer<TopicEvent, TopicEventHandler>>>>());
         
         base.AddServices(services, configurationRoot);
     }

--- a/tests/EasyMQ.E2E.Tests/appsettings.json
+++ b/tests/EasyMQ.E2E.Tests/appsettings.json
@@ -1,7 +1,8 @@
 ﻿{
   "RabbitConsumerConfigurations": [
     {
-      "EventType": "TopicEvent",
+      "EventName": "TopicEvent",
+      "EventHandlerName": "TopicEventHandler",
       "QueueName": "topic_q",
       "ExchangeName": "topic.tx",
       "ExchangeType": "topic",
@@ -15,7 +16,8 @@
       "Bindings": []
     },
     {
-      "EventType": "HeaderEvent",
+      "EventName": "HeaderEvent",
+      "EventHandlerName": "HeaderEventHandler",
       "QueueName": "header_q",
       "ExchangeName": "header.hx",
       "ExchangeType": "headers",
@@ -43,7 +45,7 @@
   ],
   "RabbitProducerConfigurations": [
     {
-      "EventType": "TopicEvent",
+      "EventName": "TopicEvent",
       "ExchangeName": "topic.tx",
       "ExchangeType": "topic",
       "ShouldDeclareExchange": true,
@@ -52,7 +54,7 @@
       "RoutingKey": "test"
     },
     {
-      "EventType": "HeaderEvent",
+      "EventName": "HeaderEvent",
       "ExchangeName": "header.hx",
       "ExchangeType": "headers",
       "ShouldDeclareExchange": true,


### PR DESCRIPTION
The THandler name is used to map the configuration. This is the ground work for implementing multiple handlers for the same event.