### PR TITLE
Implements multiple handlers for a particular event.

### DIFF
--- a/EasyMQ.EventHost/ConsumerEventHost.cs
+++ b/EasyMQ.EventHost/ConsumerEventHost.cs
@@ -130,7 +130,7 @@ public sealed class ConsumerEventHost<TConsumer> : IHostedService
             _logger.LogError("{Exception}:: {SerializeObject}", 
                 nameof(Exception), 
                 JsonConvert.SerializeObject(ex));
-            throw new ApplicationException("RMQ Exception");
+            throw;
         }
         return channel;
     }

--- a/samples/EasyMQ.Console/EasyMqTimedProducerService.cs
+++ b/samples/EasyMQ.Console/EasyMqTimedProducerService.cs
@@ -32,7 +32,15 @@ public class EasyMqTimedProducerService: IHostedService
                 {
                     Mandatory = false,
                     RoutingKey = "test"
-                });
+                }).GetAwaiter().GetResult();
+                _topicEventPublisher.Publish(new EasyMqTopicEvent()
+                {
+                    EventName = "Topic Event"
+                }, new ProducerContext()
+                {
+                    Mandatory = false,
+                    RoutingKey = "test2"
+                }).GetAwaiter().GetResult();
             };
         }
 

--- a/samples/EasyMQ.Console/EasyMqTopicEventHandler.cs
+++ b/samples/EasyMQ.Console/EasyMqTopicEventHandler.cs
@@ -33,8 +33,28 @@ public class EasyMqTopicEventHandler : IEventHandler<EasyMqTopicEvent>
     }
     public Task Handle(ReceiverContext receiverContext, EasyMqTopicEvent topicEvent)
     {
-        _logger.LogInformation("Received a new message, {event}",
+        _logger.LogInformation("Received a new message in {Name} with routing key {RoutingKey}, {Event}",
+            nameof(EasyMqTopicEventHandler),
+            receiverContext.RoutingKey,
             JsonConvert.SerializeObject(topicEvent, Formatting.Indented));
+        return Task.CompletedTask;
+    }
+}
+
+public class EasyMqTopicEventHandler2 : IEventHandler<EasyMqTopicEvent>
+{
+    private readonly ILogger<EasyMqTopicEventHandler2> _logger;
+
+    public EasyMqTopicEventHandler2(ILogger<EasyMqTopicEventHandler2> logger)
+    {
+        _logger = logger;
+    }
+    public Task Handle(ReceiverContext receiverContext, EasyMqTopicEvent @event)
+    {
+        _logger.LogInformation("Received a new message in {Name} with routing key {RoutingKey}, {Event}",
+            nameof(EasyMqTopicEventHandler2),
+            receiverContext.RoutingKey,
+            JsonConvert.SerializeObject(@event, Formatting.Indented));
         return Task.CompletedTask;
     }
 }

--- a/samples/EasyMQ.Console/Program.cs
+++ b/samples/EasyMQ.Console/Program.cs
@@ -30,6 +30,7 @@ await Host.CreateDefaultBuilder(args)
                 builder.WithProducerSection("RabbitProducerConfigurations");
             })
             .AddEventConsumer<EasyMqTopicEvent, EasyMqTopicEventHandler>()
+            .AddEventConsumer<EasyMqTopicEvent, EasyMqTopicEventHandler2>()
             .AddEventProducer<EasyMqTopicEvent>()
             .AddEventConsumer<EasyMqHeaderEvent, EasyMqHeaderEventHandler>()
             .AddEventProducer<EasyMqHeaderEvent>();

--- a/samples/EasyMQ.Console/appsettings.json
+++ b/samples/EasyMQ.Console/appsettings.json
@@ -2,6 +2,7 @@
   "RabbitConsumerConfigurations": [
     {
       "EventName": "EasyMqTopicEvent",
+      "EventHandlerName": "EasyMqTopicEventHandler",
       "QueueName": "easymq_q",
       "ExchangeName": "easymq.tx",
       "ExchangeType": "topic",
@@ -15,7 +16,23 @@
       "Bindings": []
     },
     {
+      "EventName": "EasyMqTopicEvent",
+      "EventHandlerName": "EasyMqTopicEventHandler2",
+      "QueueName": "easymq_q",
+      "ExchangeName": "easymq.tx",
+      "ExchangeType": "topic",
+      "RoutingKey": "test2",
+      "IsDurable": false,
+      "ShouldDeclareQueue": true,
+      "ShouldDeclareExchange": true,
+      "IsExclusiveQueue": false,
+      "QueueAutoDelete": true,
+      "ExchangeAutoDelete": false,
+      "Bindings": []
+    },
+    {
       "EventName": "EasyMqHeaderEvent",
+      "EventHandlerName": "EasyMqHeaderEventHandler",
       "QueueName": "header_q",
       "ExchangeName": "easymq.hx",
       "ExchangeType": "headers",

--- a/tests/EasyMQ.E2E.Tests/TestHandlers/TopicEventHandler.cs
+++ b/tests/EasyMQ.E2E.Tests/TestHandlers/TopicEventHandler.cs
@@ -25,3 +25,18 @@ public class TopicEventHandler : IEventHandler<TopicEvent>
         return Task.CompletedTask;
     }
 }
+
+public class TopicEventHandler2 : IEventHandler<TopicEvent>
+{
+    private readonly IFakeLogger _logger;
+
+    public TopicEventHandler2(IFakeLogger logger)
+    {
+        _logger = logger;
+    }
+    public Task Handle(ReceiverContext receiverContext, TopicEvent @event)
+    {
+        _logger.Log(@event.EventName);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/EasyMQ.E2E.Tests/appsettings.json
+++ b/tests/EasyMQ.E2E.Tests/appsettings.json
@@ -16,6 +16,21 @@
       "Bindings": []
     },
     {
+      "EventName": "TopicEvent",
+      "EventHandlerName": "TopicEventHandler2",
+      "QueueName": "topic_q",
+      "ExchangeName": "topic.tx",
+      "ExchangeType": "topic",
+      "RoutingKey": "test2",
+      "IsDurable": false,
+      "ShouldDeclareQueue": true,
+      "ShouldDeclareExchange": true,
+      "IsExclusiveQueue": false,
+      "QueueAutoDelete": false,
+      "ExchangeAutoDelete": false,
+      "Bindings": []
+    },
+    {
       "EventName": "HeaderEvent",
       "EventHandlerName": "HeaderEventHandler",
       "QueueName": "header_q",


### PR DESCRIPTION
The configuration now accepts the corresponding handler name. Using this name a particular IEvent type is mapped to the respective IEventHandler<TEvent>.

NOTE:- The message itself is not duplicated across the various handlers.